### PR TITLE
Build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: python
 services:
   - docker
 
-branches:
-  only:
-    - master
-
 env:
   global:
     - COREOS_RELEASE_CHANNEL=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     - SHELLCHECK_VERSION=v0.5.0
   matrix:
     - >
-      NVIDIA_DRIVER_URL=http://us.download.nvidia.com/tesla/396.44/NVIDIA-Linux-x86_64-396.44.run
-      NVIDIA_DRIVER_VERSION=396.44
+      NVIDIA_DRIVER_URL=http://us.download.nvidia.com/tesla/418.67/NVIDIA-Linux-x86_64-418.67.run
+      NVIDIA_DRIVER_VERSION=418.67
 
 install:
   - docker pull koalaman/shellcheck:$SHELLCHECK_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get -y update && \
     libssl-dev \
     module-init-tools \
     p7zip-full \
+    bison \
+    flex \
     libelf-dev && \
     apt-get autoremove && \
     apt-get clean
@@ -51,6 +53,7 @@ RUN 7z e /tmp/coreos_developer_container.bin "usr/lib64/modules/*-coreos*/build/
 RUN 7z e /tmp/coreos_developer_container.bin "usr/lib64/modules/*-coreos*/build/include/config/kernel.release" && cp kernel.release /tmp/kernel.release
 
 # Prepare kernel source tree to build external modules
+RUN make oldconfig
 RUN make modules_prepare
 RUN sed -i -e "s/${KERNEL_VERSION}/$(cat /tmp/kernel.release)/" include/generated/utsrelease.h
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN "${NVIDIA_PATH}/download/driver.run" \
     --ui=none
 
 # Build kernel modules
-RUN "${NVIDIA_INSTALLER}" \
+RUN IGNORE_MISSING_MODULE_SYMVERS=1 "${NVIDIA_INSTALLER}" \
     --accept-license \
     --no-questions \
     --ui=none \


### PR DESCRIPTION
This should fix your broken build-pipeline. (see https://travis-ci.org/mriedmann/nvidia4coreos)

Please mind that I also updated this to the latest nvidia-diver version and removed the master-branch limitation on the travis config. You can simply change this back if you would like to keep your defaults.

Thx for this great project!
